### PR TITLE
Add rpatchur patch system for XileRO client

### DIFF
--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -12,6 +12,7 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
@@ -54,6 +55,10 @@ class PatchResource extends Resource
                     ->description('Configure the basic settings for your patch')
                     ->icon('heroicon-o-information-circle')
                     ->schema([
+                        // Patcher is derived from the client (XileRO => rpatchur, XileRetro => legacy),
+                        // so it is carried as hidden state rather than shown as a redundant field.
+                        Hidden::make('patcher')
+                            ->default(Patch::PATCHER_RPATCHUR),
                         Grid::make(2)
                             ->schema([
                                 Select::make('client')
@@ -62,55 +67,33 @@ class PatchResource extends Resource
                                     ->native(false)
                                     ->selectablePlaceholder(false)
                                     ->default(Patch::CLIENT_XILERO)
-                                    ->helperText('Select which client this patch is for')
+                                    ->helperText('XileRO uses rpatchur, XileRetro uses neoncube (legacy)')
                                     ->live()
                                     ->afterStateUpdated(function ($state, Get $get, $set) {
                                         $client = $state ?: Patch::CLIENT_XILERO;
-                                        // Retro is legacy-only (neoncube); XileRO keeps its rpatchur selection.
-                                        $patcher = $client === Patch::CLIENT_RETRO
-                                            ? Patch::PATCHER_LEGACY
-                                            : ($get('patcher') ?: Patch::PATCHER_RPATCHUR);
+                                        $patcher = Patch::patcherForClient($client);
                                         $set('patcher', $patcher);
                                         $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
                                         $set('number', $maxNumber ? $maxNumber + 1 : 1);
                                     })
                                     ->required(),
-                                Select::make('patcher')
-                                    ->label('Patcher')
-                                    ->options(fn (Get $get): array => $get('client') === Patch::CLIENT_RETRO
-                                        ? [Patch::PATCHER_LEGACY => Patch::PATCHERS[Patch::PATCHER_LEGACY]]
-                                        : Patch::PATCHERS)
-                                    ->disabled(fn (Get $get): bool => $get('client') === Patch::CLIENT_RETRO)
-                                    ->dehydrated()
+                                Select::make('type')
+                                    ->label('Patch Type')
+                                    ->options([
+                                        'FLD' => 'FLD - Root Folder Patch',
+                                        'GRF' => 'GRF - GRF File Patch',
+                                    ])
                                     ->native(false)
                                     ->selectablePlaceholder(false)
-                                    ->default(Patch::PATCHER_RPATCHUR)
-                                    ->helperText('rpatchur serves .thor/.grf to the new launcher; Legacy serves .gpf to the old Thor patcher')
-                                    ->live()
-                                    ->afterStateUpdated(function ($state, Get $get, $set) {
-                                        $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                        $patcher = $state ?: Patch::PATCHER_RPATCHUR;
-                                        $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
-                                        $set('number', $maxNumber ? $maxNumber + 1 : 1);
-                                    })
+                                    ->default('FLD')
+                                    ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
                                     ->required(),
                             ]),
-                        Select::make('type')
-                            ->label('Patch Type')
-                            ->options([
-                                'FLD' => 'FLD - Root Folder Patch',
-                                'GRF' => 'GRF - GRF File Patch',
-                            ])
-                            ->native(false)
-                            ->selectablePlaceholder(false)
-                            ->default('FLD')
-                            ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
-                            ->required(),
                         TextInput::make('number')
                             ->label('Patch Number')
                             ->default(function (Get $get) {
                                 $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                $patcher = $get('patcher') ?: Patch::PATCHER_RPATCHUR;
+                                $patcher = Patch::patcherForClient($client);
                                 $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
 
                                 return $maxNumber ? $maxNumber + 1 : 1;

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -66,7 +66,8 @@ class PatchResource extends Resource
                                     ->selectablePlaceholder(false)
                                     ->default('FLD')
                                     ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
-                                    ->required(),
+                                    ->required()
+                                    ->visible(fn (Get $get): bool => $get('patcher') !== Patch::PATCHER_RPATCHUR),
                                 Select::make('client')
                                     ->label('Client')
                                     ->options(Patch::CLIENTS)
@@ -122,6 +123,11 @@ class PatchResource extends Resource
                             ->required(fn (string $context): bool => $context === 'create')
                             ->disk(fn (Get $get): string => self::diskFor($get('client'), $get('patcher')))
                             ->directory('')
+                            ->rules(fn (Get $get): array => [
+                                $get('patcher') === Patch::PATCHER_LEGACY
+                                    ? 'extensions:gpf'
+                                    : 'extensions:thor,grf',
+                            ])
                             ->maxSize(102400)
                             ->downloadable()
                             ->helperText(fn (Get $get): string => $get('patcher') === Patch::PATCHER_LEGACY

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -56,18 +56,6 @@ class PatchResource extends Resource
                     ->schema([
                         Grid::make(2)
                             ->schema([
-                                Select::make('type')
-                                    ->label('Patch Type')
-                                    ->options([
-                                        'FLD' => 'FLD - Root Folder Patch',
-                                        'GRF' => 'GRF - GRF File Patch',
-                                    ])
-                                    ->native(false)
-                                    ->selectablePlaceholder(false)
-                                    ->default('FLD')
-                                    ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
-                                    ->required()
-                                    ->visible(fn (Get $get): bool => $get('patcher') !== Patch::PATCHER_RPATCHUR),
                                 Select::make('client')
                                     ->label('Client')
                                     ->options(Patch::CLIENTS)
@@ -87,26 +75,38 @@ class PatchResource extends Resource
                                         $set('number', $maxNumber ? $maxNumber + 1 : 1);
                                     })
                                     ->required(),
+                                Select::make('patcher')
+                                    ->label('Patcher')
+                                    ->options(fn (Get $get): array => $get('client') === Patch::CLIENT_RETRO
+                                        ? [Patch::PATCHER_LEGACY => Patch::PATCHERS[Patch::PATCHER_LEGACY]]
+                                        : Patch::PATCHERS)
+                                    ->disabled(fn (Get $get): bool => $get('client') === Patch::CLIENT_RETRO)
+                                    ->dehydrated()
+                                    ->native(false)
+                                    ->selectablePlaceholder(false)
+                                    ->default(Patch::PATCHER_RPATCHUR)
+                                    ->helperText('rpatchur serves .thor/.grf to the new launcher; Legacy serves .gpf to the old Thor patcher')
+                                    ->live()
+                                    ->afterStateUpdated(function ($state, Get $get, $set) {
+                                        $client = $get('client') ?: Patch::CLIENT_XILERO;
+                                        $patcher = $state ?: Patch::PATCHER_RPATCHUR;
+                                        $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
+                                        $set('number', $maxNumber ? $maxNumber + 1 : 1);
+                                    })
+                                    ->required(),
                             ]),
-                        Select::make('patcher')
-                            ->label('Patcher')
-                            ->options(fn (Get $get): array => $get('client') === Patch::CLIENT_RETRO
-                                ? [Patch::PATCHER_LEGACY => Patch::PATCHERS[Patch::PATCHER_LEGACY]]
-                                : Patch::PATCHERS)
-                            ->disabled(fn (Get $get): bool => $get('client') === Patch::CLIENT_RETRO)
-                            ->dehydrated()
+                        Select::make('type')
+                            ->label('Patch Type')
+                            ->options([
+                                'FLD' => 'FLD - Root Folder Patch',
+                                'GRF' => 'GRF - GRF File Patch',
+                            ])
                             ->native(false)
                             ->selectablePlaceholder(false)
-                            ->default(Patch::PATCHER_RPATCHUR)
-                            ->helperText('rpatchur serves .thor/.grf to the new launcher; Legacy serves .gpf to the old Thor patcher')
-                            ->live()
-                            ->afterStateUpdated(function ($state, Get $get, $set) {
-                                $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                $patcher = $state ?: Patch::PATCHER_RPATCHUR;
-                                $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
-                                $set('number', $maxNumber ? $maxNumber + 1 : 1);
-                            })
-                            ->required(),
+                            ->default('FLD')
+                            ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
+                            ->required()
+                            ->visible(fn (Get $get): bool => $get('patcher') !== Patch::PATCHER_RPATCHUR),
                         TextInput::make('number')
                             ->label('Patch Number')
                             ->default(function (Get $get) {

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -210,7 +210,8 @@ class PatchResource extends Resource
                             ->label('')
                             ->content(function (Get $get) {
                                 $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                $recent_patches = Patch::where('client', $client)->latest('number')->take(5)->get();
+                                $patcher = $get('patcher') ?: Patch::PATCHER_LEGACY;
+                                $recent_patches = Patch::where('client', $client)->where('patcher', $patcher)->latest('number')->take(5)->get();
 
                                 if ($recent_patches->isEmpty()) {
                                     return new HtmlString('<p class="text-sm text-gray-500">No patches found for '.($client === 'retro' ? 'Retro' : 'XileRO').'</p>');

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -168,7 +168,8 @@ class PatchResource extends Resource
                                     ->label('Post Title')
                                     ->placeholder(function (Get $get) {
                                         $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                        $maxNumber = Patch::where('client', $client)->max('number');
+                                        $patcher = $get('patcher') ?: Patch::PATCHER_LEGACY;
+                                        $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
                                         $next_number = $maxNumber ? $maxNumber + 1 : 1;
 
                                         return 'e.g., Patch #'.$next_number.' - Halloween Update';

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -105,8 +105,7 @@ class PatchResource extends Resource
                             ->selectablePlaceholder(false)
                             ->default('FLD')
                             ->helperText('FLD patches to the Root folder, GRF patches to the GRF file')
-                            ->required()
-                            ->visible(fn (Get $get): bool => $get('patcher') !== Patch::PATCHER_RPATCHUR),
+                            ->required(),
                         TextInput::make('number')
                             ->label('Patch Number')
                             ->default(function (Get $get) {

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -78,7 +78,11 @@ class PatchResource extends Resource
                                     ->live()
                                     ->afterStateUpdated(function ($state, Get $get, $set) {
                                         $client = $state ?: Patch::CLIENT_XILERO;
-                                        $patcher = $get('patcher') ?: Patch::PATCHER_RPATCHUR;
+                                        // Retro is legacy-only (neoncube); XileRO keeps its rpatchur selection.
+                                        $patcher = $client === Patch::CLIENT_RETRO
+                                            ? Patch::PATCHER_LEGACY
+                                            : ($get('patcher') ?: Patch::PATCHER_RPATCHUR);
+                                        $set('patcher', $patcher);
                                         $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
                                         $set('number', $maxNumber ? $maxNumber + 1 : 1);
                                     })
@@ -86,7 +90,11 @@ class PatchResource extends Resource
                             ]),
                         Select::make('patcher')
                             ->label('Patcher')
-                            ->options(Patch::PATCHERS)
+                            ->options(fn (Get $get): array => $get('client') === Patch::CLIENT_RETRO
+                                ? [Patch::PATCHER_LEGACY => Patch::PATCHERS[Patch::PATCHER_LEGACY]]
+                                : Patch::PATCHERS)
+                            ->disabled(fn (Get $get): bool => $get('client') === Patch::CLIENT_RETRO)
+                            ->dehydrated()
                             ->native(false)
                             ->selectablePlaceholder(false)
                             ->default(Patch::PATCHER_RPATCHUR)

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -75,19 +75,35 @@ class PatchResource extends Resource
                                     ->default(Patch::CLIENT_XILERO)
                                     ->helperText('Select which client this patch is for')
                                     ->live()
-                                    ->afterStateUpdated(function ($state, $set) {
+                                    ->afterStateUpdated(function ($state, Get $get, $set) {
                                         $client = $state ?: Patch::CLIENT_XILERO;
-                                        $maxNumber = Patch::where('client', $client)->max('number');
-                                        $nextNumber = $maxNumber ? $maxNumber + 1 : 1;
-                                        $set('number', $nextNumber);
+                                        $patcher = $get('patcher') ?: Patch::PATCHER_RPATCHUR;
+                                        $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
+                                        $set('number', $maxNumber ? $maxNumber + 1 : 1);
                                     })
                                     ->required(),
                             ]),
+                        Select::make('patcher')
+                            ->label('Patcher')
+                            ->options(Patch::PATCHERS)
+                            ->native(false)
+                            ->selectablePlaceholder(false)
+                            ->default(Patch::PATCHER_RPATCHUR)
+                            ->helperText('rpatchur serves .thor/.grf to the new launcher; Legacy serves .gpf to the old Thor patcher')
+                            ->live()
+                            ->afterStateUpdated(function ($state, Get $get, $set) {
+                                $client = $get('client') ?: Patch::CLIENT_XILERO;
+                                $patcher = $state ?: Patch::PATCHER_RPATCHUR;
+                                $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
+                                $set('number', $maxNumber ? $maxNumber + 1 : 1);
+                            })
+                            ->required(),
                         TextInput::make('number')
                             ->label('Patch Number')
                             ->default(function (Get $get) {
                                 $client = $get('client') ?: Patch::CLIENT_XILERO;
-                                $maxNumber = Patch::where('client', $client)->max('number');
+                                $patcher = $get('patcher') ?: Patch::PATCHER_RPATCHUR;
+                                $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
 
                                 return $maxNumber ? $maxNumber + 1 : 1;
                             })
@@ -98,25 +114,19 @@ class PatchResource extends Resource
                     ]),
 
                 Section::make('Upload Patch File')
-                    ->description('Select the .gpf patch file to upload')
+                    ->description('rpatchur: upload a .thor (or .grf) built with mkpatch. Legacy: upload a .gpf.')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->schema([
                         FileUpload::make('file')
                             ->label('Patch File')
                             ->required(fn (string $context): bool => $context === 'create')
-                            ->disk(function (Get $get): string {
-                                $client = $get('client') ?? 'xilero';
-
-                                return match ($client) {
-                                    'retro' => 'retro_patch',
-                                    'xilero' => 'xilero_patch',
-                                    default => 'xilero_patch'
-                                };
-                            })
+                            ->disk(fn (Get $get): string => self::diskFor($get('client'), $get('patcher')))
                             ->directory('')
                             ->maxSize(102400)
                             ->downloadable()
-                            ->helperText('Upload a .gpf patch file (max 100MB)')
+                            ->helperText(fn (Get $get): string => $get('patcher') === Patch::PATCHER_LEGACY
+                                ? 'Upload a .gpf patch file (max 100MB)'
+                                : 'Upload a .thor or .grf patch file built with mkpatch (max 100MB)')
                             ->preserveFilenames()
                             ->storeFileNamesIn('patch_name'),
 
@@ -359,15 +369,8 @@ class PatchResource extends Resource
                         if (! $record->file) {
                             return '#';
                         }
-                        $client = $record->client ?? 'xilero';
-                        $disk = match ($client) {
-                            'retro' => 'retro_patch',
-                            'xilero' => 'xilero_patch',
-                            default => 'xilero_patch'
-                        };
 
-                        // Use Storage facade to get the proper URL
-                        return Storage::disk($disk)->url($record->file);
+                        return Storage::disk($record->diskName())->url($record->file);
                     })
                     ->openUrlInNewTab()
                     ->visible(fn (Patch $record): bool => ! empty($record->file)),
@@ -404,5 +407,20 @@ class PatchResource extends Resource
             'create' => CreatePatch::route('/create'),
             'edit' => EditPatch::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * Resolve the storage disk for a patch's client + patcher combination.
+     */
+    public static function diskFor(?string $client, ?string $patcher): string
+    {
+        $client ??= Patch::CLIENT_XILERO;
+        $patcher ??= Patch::PATCHER_RPATCHUR;
+
+        if ($patcher === Patch::PATCHER_RPATCHUR) {
+            return $client === Patch::CLIENT_RETRO ? 'retro_rpatchur' : 'xilero_rpatchur';
+        }
+
+        return $client === Patch::CLIENT_RETRO ? 'retro_patch' : 'xilero_patch';
     }
 }

--- a/app/Filament/Resources/PatchResource.php
+++ b/app/Filament/Resources/PatchResource.php
@@ -418,7 +418,7 @@ class PatchResource extends Resource
         $patcher ??= Patch::PATCHER_RPATCHUR;
 
         if ($patcher === Patch::PATCHER_RPATCHUR) {
-            return $client === Patch::CLIENT_RETRO ? 'retro_rpatchur' : 'xilero_rpatchur';
+            return 'xilero_rpatchur';
         }
 
         return $client === Patch::CLIENT_RETRO ? 'retro_patch' : 'xilero_patch';

--- a/app/Filament/Resources/PatchResource/Pages/CreatePatch.php
+++ b/app/Filament/Resources/PatchResource/Pages/CreatePatch.php
@@ -16,9 +16,13 @@ class CreatePatch extends CreateRecord
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
-        // Calculate the correct patch number for the selected client
+        // Patcher is derived from the client (XileRO => rpatchur, XileRetro => legacy).
         $client = $data['client'];
-        $maxNumber = Patch::where('client', $client)->max('number');
+        $patcher = Patch::patcherForClient($client);
+        $data['patcher'] = $patcher;
+
+        // Calculate the correct patch number for this client + patcher.
+        $maxNumber = Patch::where('client', $client)->where('patcher', $patcher)->max('number');
         $data['number'] = $maxNumber ? $maxNumber + 1 : 1;
 
         // Mark as compiling immediately since we'll auto-compile

--- a/app/Jobs/CompilePatch.php
+++ b/app/Jobs/CompilePatch.php
@@ -36,7 +36,7 @@ class CompilePatch implements ShouldQueue
         ItemInfoParser $itemInfoParser,
         GrfImageExtractor $imageExtractor
     ): void {
-        $disk = $this->getDiskForClient($this->patch->client);
+        $disk = $this->patch->diskName();
         $filePath = $this->patch->file;
 
         if (! $filePath || ! Storage::disk($disk)->exists($filePath)) {

--- a/app/Jobs/CompilePatch.php
+++ b/app/Jobs/CompilePatch.php
@@ -149,16 +149,4 @@ class CompilePatch implements ShouldQueue
             }
         }
     }
-
-    /**
-     * Get the storage disk name for the given client.
-     */
-    private function getDiskForClient(string $client): string
-    {
-        return match ($client) {
-            Patch::CLIENT_RETRO => 'retro_patch',
-            Patch::CLIENT_XILERO => 'xilero_patch',
-            default => 'xilero_patch',
-        };
-    }
 }

--- a/app/Models/Patch.php
+++ b/app/Models/Patch.php
@@ -20,10 +20,20 @@ class Patch extends Model
         self::CLIENT_XILERO => 'XileRO',
     ];
 
+    const PATCHER_LEGACY = 'legacy';
+
+    const PATCHER_RPATCHUR = 'rpatchur';
+
+    const PATCHERS = [
+        self::PATCHER_LEGACY => 'Legacy (Thor / .gpf)',
+        self::PATCHER_RPATCHUR => 'rpatchur (.thor / .grf)',
+    ];
+
     protected $fillable = [
         'number',
         'type',
         'client',
+        'patcher',
         'patch_name',
         'file',
         'comments',
@@ -31,6 +41,18 @@ class Patch extends Model
         'is_compiling',
         'compiled_at',
     ];
+
+    /**
+     * Storage disk that holds this patch's uploaded file.
+     */
+    public function diskName(): string
+    {
+        if ($this->patcher === self::PATCHER_RPATCHUR) {
+            return $this->client === self::CLIENT_RETRO ? 'retro_rpatchur' : 'xilero_rpatchur';
+        }
+
+        return $this->client === self::CLIENT_RETRO ? 'retro_patch' : 'xilero_patch';
+    }
 
     protected function casts(): array
     {

--- a/app/Models/Patch.php
+++ b/app/Models/Patch.php
@@ -43,6 +43,14 @@ class Patch extends Model
     ];
 
     /**
+     * The patcher a client serves with: XileRO uses rpatchur, XileRetro uses neoncube (legacy).
+     */
+    public static function patcherForClient(string $client): string
+    {
+        return $client === self::CLIENT_RETRO ? self::PATCHER_LEGACY : self::PATCHER_RPATCHUR;
+    }
+
+    /**
      * Storage disk that holds this patch's uploaded file.
      */
     public function diskName(): string

--- a/app/Models/Patch.php
+++ b/app/Models/Patch.php
@@ -48,7 +48,7 @@ class Patch extends Model
     public function diskName(): string
     {
         if ($this->patcher === self::PATCHER_RPATCHUR) {
-            return $this->client === self::CLIENT_RETRO ? 'retro_rpatchur' : 'xilero_rpatchur';
+            return 'xilero_rpatchur';
         }
 
         return $this->client === self::CLIENT_RETRO ? 'retro_patch' : 'xilero_patch';

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -106,6 +106,7 @@ return [
     'links' => [
         public_path('storage') => storage_path('app/public'),
         public_path('xilero/patch') => storage_path('app/public/xilero/patch'),
+        public_path('xilero/rpatchur') => storage_path('app/public/xilero/rpatchur'),
         public_path('retro/patch') => storage_path('app/public/retro/patch'),
         public_path('storage/android/apk') => storage_path('app/public/android/apk'),
     ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -64,6 +64,16 @@ return [
             'throw' => false,
         ],
 
+        // THOR/GRF patches served to the modern rpatchur launcher (xilero client).
+        // Kept separate from the legacy .gpf `xilero_patch` disk.
+        'xilero_rpatchur' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public/xilero/rpatchur'),
+            'url' => env('APP_URL').'/storage/xilero/rpatchur',
+            'visibility' => 'public',
+            'throw' => false,
+        ],
+
         'retro_patch' => [
             'driver' => 'local',
             'root' => storage_path('app/public/retro/patch'),

--- a/database/factories/PatchFactory.php
+++ b/database/factories/PatchFactory.php
@@ -6,7 +6,7 @@ use App\Models\Patch;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Patch>
+ * @extends Factory<Patch>
  */
 class PatchFactory extends Factory
 {
@@ -19,6 +19,7 @@ class PatchFactory extends Factory
     {
         return [
             'number' => fake()->unique()->numberBetween(1, 10000),
+            'patcher' => Patch::PATCHER_LEGACY,
             'type' => fake()->randomElement(['FLD', 'GRF']),
             'client' => fake()->randomElement([Patch::CLIENT_XILERO, Patch::CLIENT_RETRO]),
             'patch_name' => fake()->sentence(3),

--- a/database/migrations/2026_06_19_213848_add_patcher_to_patches_table.php
+++ b/database/migrations/2026_06_19_213848_add_patcher_to_patches_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('patches', function (Blueprint $table) {
+            // 'legacy'   = historical .gpf patches for the old Thor patcher
+            // 'rpatchur' = .thor/.grf patches served to the modern rpatchur launcher
+            $table->string('patcher')->default('legacy')->after('client')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('patches', function (Blueprint $table) {
+            $table->dropIndex(['patcher']);
+            $table->dropColumn('patcher');
+        });
+    }
+};

--- a/database/migrations/2026_06_20_093147_set_default_type_on_patches_table.php
+++ b/database/migrations/2026_06_20_093147_set_default_type_on_patches_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('patches', function (Blueprint $table): void {
+            $table->string('type')->default('FLD')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('patches', function (Blueprint $table): void {
+            $table->string('type')->default(null)->change();
+        });
+    }
+};

--- a/resources/views/rpatchur.blade.php
+++ b/resources/views/rpatchur.blade.php
@@ -227,9 +227,19 @@
 
     function el(id) { return document.getElementById(id); }
 
+    /* rpatchur injects window.external.invoke into its webview; it is absent in a
+       normal browser, so fall back to native behaviour for local testing. */
+    function hasBridge() { return typeof external !== 'undefined' && external.invoke; }
+
     /* Plain-string commands. Only login/open_url use the JSON form in rpatchur. */
-    function rpc(cmd) { external.invoke(cmd); }
-    function openUrl(u) { external.invoke(JSON.stringify({ function: 'open_url', parameters: { url: u } })); }
+    function rpc(cmd) {
+        if (hasBridge()) { external.invoke(cmd); }
+        else { console.warn('rpatchur bridge unavailable for command: ' + cmd); }
+    }
+    function openUrl(u) {
+        if (hasBridge()) { external.invoke(JSON.stringify({ function: 'open_url', parameters: { url: u } })); }
+        else { window.open(u, '_blank'); }
+    }
 
     function selectPost(node) {
         var posts = document.getElementsByClassName('post');

--- a/resources/views/rpatchur.blade.php
+++ b/resources/views/rpatchur.blade.php
@@ -93,6 +93,8 @@
         border-radius:50%; border-top:1.5px solid rgba(178,226,255,.42);
         background:radial-gradient(circle at 50% 26%, rgba(124,188,248,.32), rgba(24,42,96,.4) 52%, transparent 70%);
         box-shadow:inset 0 12px 50px rgba(150,210,255,.32), 0 -2px 46px rgba(120,200,255,.22); }
+    .hero-img { position:absolute; top:0; left:0; right:0; bottom:0;
+        background-position:center; background-repeat:no-repeat; background-size:cover; }
     .hero-cap { position:absolute; left:0; right:0; bottom:0; padding:18px 16px 16px;
         background:linear-gradient(180deg, transparent, rgba(9,8,22,.9) 58%); }
     .hero-badge { display:inline-block; font-size:10px; font-weight:800; letter-spacing:.6px; color:#fff;
@@ -188,6 +190,9 @@
             <div class="hero-bg"></div>
             <div class="hero-dots"></div>
             <div class="hero-planet"></div>
+            @if ($posts->isNotEmpty() && $posts->first()->image)
+                <div class="hero-img" style="background-image:url('{{ Storage::disk('public')->url($posts->first()->image) }}')"></div>
+            @endif
             <div class="hero-cap">
                 <div class="hero-badge">&#9733; LATEST UPDATE</div>
                 @if ($posts->isNotEmpty())

--- a/resources/views/rpatchur.blade.php
+++ b/resources/views/rpatchur.blade.php
@@ -166,27 +166,21 @@
                 <div class="feed-sub">News, patches &amp; announcements</div>
             </div>
             <div class="xr-feed">
-                @php
-                    $news = $news ?? [
-                        ['tag' => 'pinned', 'label' => 'PINNED', 'date' => 'Always',
-                         'title' => 'Always run your Patcher! ♥',
-                         'body'  => 'Keep the launcher open until patching finishes — it pulls the latest client files so you never fall behind on events.'],
-                        ['tag' => 'update', 'label' => 'UPDATE', 'date' => '4 weeks ago',
-                         'title' => 'New Systems, New Content & Major Changes Ahead',
-                         'body'  => 'We’re testing a few more things and making final adjustments — expect a big content drop for XileRetro very soon.'],
-                        ['tag' => 'event', 'label' => 'EVENT', 'date' => 'April 2026',
-                         'title' => 'Cherry Blossom Bloom',
-                         'body'  => 'Spring has arrived in Rune-Midgard with seasonal quests, blossom drops and limited-time gear.'],
-                    ];
-                @endphp
-                @foreach ($news as $i => $post)
-                    <div class="post {{ $i === 0 ? 'sel' : '' }}" onclick="selectPost(this)">
-                        <span class="tag {{ $post['tag'] }}">{{ $post['label'] }}</span>
-                        <span class="date">{{ $post['date'] }}</span>
-                        <div class="title">{{ $post['title'] }}</div>
-                        <div class="body">{{ $post['body'] }}</div>
+                @forelse ($posts as $post)
+                    <div class="post {{ $loop->first ? ‘sel’ : ‘’ }}" onclick="selectPost(this)">
+                        <span class="tag update">UPDATE</span>
+                        <span class="date">{{ $post->created_at->format(‘M j, Y’) }}</span>
+                        <div class="title">{{ $post->title }}</div>
+                        <div class="body">{{ Str::limit($post->patcher_notice ?: strip_tags($post->article_content), 120) }}</div>
                     </div>
-                @endforeach
+                @empty
+                    <div class="post sel">
+                        <span class="tag update">UPDATE</span>
+                        <span class="date">Always</span>
+                        <div class="title">Always run your Patcher!</div>
+                        <div class="body">Keep the launcher open until patching finishes — it pulls the latest client files so you never fall behind on events.</div>
+                    </div>
+                @endforelse
             </div>
         </div>
 
@@ -195,9 +189,14 @@
             <div class="hero-dots"></div>
             <div class="hero-planet"></div>
             <div class="hero-cap">
-                <div class="hero-badge">&#9733; FEATURED EVENT</div>
-                <div class="hero-title">Cherry Blossom Bloom</div>
-                <div class="hero-sub">Spring quests &amp; seasonal gear &middot; April 2026</div>
+                <div class="hero-badge">&#9733; LATEST UPDATE</div>
+                @if ($posts->isNotEmpty())
+                    <div class="hero-title">{{ $posts->first()->title }}</div>
+                    <div class="hero-sub">{{ $posts->first()->created_at->format('F Y') }}</div>
+                @else
+                    <div class="hero-title">Welcome to XileRO</div>
+                    <div class="hero-sub">Classic Ragnarok Online Private Server</div>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/rpatchur.blade.php
+++ b/resources/views/rpatchur.blade.php
@@ -1,153 +1,296 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>XileRO Patcher</title>
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: 'Segoe UI', Tahoma, sans-serif;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
-            color: #fff;
-            height: 100vh;
-            display: flex;
-            flex-direction: column;
-            user-select: none;
-            overflow: hidden;
-        }
-        .header { text-align: center; padding: 30px 20px 20px; }
-        .header h1 {
-            font-size: 32px;
-            font-weight: 300;
-            letter-spacing: 4px;
-            text-transform: uppercase;
-            color: #e94560;
-            text-shadow: 0 0 20px rgba(233, 69, 96, 0.5);
-        }
-        .content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            padding: 20px;
-        }
-        .status-container { width: 100%; max-width: 500px; margin-bottom: 30px; }
-        .status-text {
-            font-size: 14px;
-            color: #a0a0a0;
-            margin-bottom: 10px;
-            text-align: center;
-            min-height: 20px;
-        }
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(255, 255, 255, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-        }
-        .progress-fill {
-            width: 0%;
-            height: 100%;
-            background: linear-gradient(90deg, #e94560, #ff6b6b);
-            border-radius: 4px;
-            transition: width 0.3s ease;
-        }
-        .buttons { display: flex; gap: 15px; }
-        .btn {
-            padding: 12px 40px;
-            font-size: 14px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-        .btn-play {
-            background: linear-gradient(135deg, #e94560, #ff6b6b);
-            color: #fff;
-        }
-        .btn-play:hover:not(:disabled) {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(233, 69, 96, 0.4);
-        }
-        .btn-play:disabled { background: #555; cursor: not-allowed; }
-        .btn-setup {
-            background: transparent;
-            color: #a0a0a0;
-            border: 1px solid #a0a0a0;
-        }
-        .btn-setup:hover { color: #fff; border-color: #fff; }
-        .footer { text-align: center; padding: 15px; font-size: 11px; color: #555; }
-    </style>
+<meta charset="UTF-8">
+{{-- rpatchur (web-view 0.7.3) renders with MSHTML on Windows; IE=edge forces IE11 mode.
+     Everything below is intentionally IE11-safe: literal colours (no CSS vars / color-mix),
+     margins instead of flex `gap`, no woff2 webfont, no CSS filter:blur. --}}
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<!-- Sentinel "browser-logger-active": Laravel Boost's InjectBoost middleware skips
+     pages already containing this string, preventing it from injecting its modern-JS
+     console logger (const/WeakSet/arrow fns) that IE11 can't parse. Must be a real
+     HTML comment (Blade {{-- --}} comments are stripped before output). -->
+<title>XileRO Launcher</title>
+<style>
+    * { margin:0; padding:0; box-sizing:border-box; }
+    html, body { width:100%; height:100%; overflow:hidden; background:#0c0b18; }
+    body { font-family:'Segoe UI', Tahoma, Geneva, sans-serif; color:#eceaf7; user-select:none; -ms-user-select:none; }
+
+    @keyframes xrShimmer { 0% { transform:translateX(-100%); } 100% { transform:translateX(220%); } }
+    @keyframes xrPulse   { 0% { opacity:.5; } 50% { opacity:1; } 100% { opacity:.5; } }
+
+    .xr-feed { overflow-y:auto; }
+    .xr-feed::-webkit-scrollbar { width:7px; }
+    .xr-feed::-webkit-scrollbar-track { background:transparent; }
+    .xr-feed::-webkit-scrollbar-thumb { background:rgba(255,255,255,.12); border-radius:8px; }
+
+    .shell { position:absolute; top:0; left:0; right:0; bottom:0; background:#16142b;
+             border:1px solid rgba(255,255,255,.07); overflow:hidden; }
+
+    /* Title bar */
+    .titlebar { height:52px; background:#181631; border-bottom:1px solid rgba(255,255,255,.06);
+                position:relative; z-index:6; }
+    .tb-left { position:absolute; left:18px; top:0; height:52px; }
+    .tb-right { position:absolute; right:14px; top:10px; }
+    .logo { float:left; width:28px; height:28px; margin-top:12px; border-radius:8px; text-align:center;
+            line-height:28px; font-weight:800; font-size:15px; color:#fff;
+            background:linear-gradient(135deg,#8b7bf2,#d76ad0); box-shadow:0 4px 12px -2px rgba(139,123,242,.55); }
+    .brand { float:left; margin:16px 0 0 11px; }
+    .brand b { font-weight:800; letter-spacing:.5px; font-size:16px; }
+    .brand span { font-weight:500; font-size:12px; color:#8e8cb0; margin-left:8px; }
+    .ver { float:left; margin:17px 0 0 10px; font-size:11px; font-weight:600; color:#a8a4d8;
+           background:rgba(255,255,255,.06); padding:2px 8px; border-radius:999px; }
+    .winbtn { float:left; width:32px; height:32px; margin-left:6px; text-align:center; line-height:32px;
+              border-radius:8px; color:#9a98bd; cursor:pointer; }
+    .winbtn:hover { background:rgba(255,255,255,.08); color:#eceaf7; }
+    .winbtn.close:hover { background:#cf4d6e; color:#fff; }
+
+    /* Toolbar */
+    .toolbar { height:58px; background:#161430; border-bottom:1px solid rgba(255,255,255,.05);
+               position:relative; z-index:6; }
+    .nav { position:absolute; left:14px; top:11px; }
+    .nav a { float:left; height:36px; line-height:36px; padding:0 15px; border-radius:9px; color:#c4c2e0;
+             font-weight:600; font-size:13.5px; cursor:pointer; text-decoration:none; }
+    .nav a:hover { background:rgba(255,255,255,.06); color:#fff; }
+    .status-pill { position:absolute; right:18px; top:20px; font-size:12.5px; font-weight:600; }
+    .dot { display:inline-block; width:8px; height:8px; border-radius:50%; vertical-align:middle;
+           margin-right:7px; }
+    .srv-on { color:#46d18a; } .srv-on .dot { background:#46d18a; box-shadow:0 0 9px #46d18a; animation:xrPulse 2.4s infinite; }
+    .sep { color:#3e3c5e; margin:0 11px; } .online { color:#9a98bd; }
+
+    /* Stage */
+    .stage { position:absolute; left:0; right:0; top:110px; bottom:120px; padding:22px; background:#14122a; z-index:5; }
+    .feed-col { position:absolute; left:22px; top:22px; bottom:22px; right:370px; }
+    .feed-head { font-size:18px; font-weight:800; color:#f3f1fb; }
+    .feed-sub  { font-size:12.5px; color:#8e8cb0; margin-top:2px; }
+    .viewall { float:right; font-size:12.5px; font-weight:700; color:#8b7bf2; cursor:pointer; }
+    .xr-feed { position:absolute; left:0; right:-9px; top:48px; bottom:0; padding-right:9px; }
+    .post { position:relative; padding:15px 17px; margin-bottom:11px; border-radius:14px;
+            background:rgba(255,255,255,.025); border:1px solid rgba(255,255,255,.07); cursor:pointer; }
+    .post:hover { border-color:rgba(255,255,255,.16); }
+    .post.sel { background:rgba(255,255,255,.06); border-color:rgba(139,123,242,.45); }
+    .tag { display:inline-block; font-size:10.5px; font-weight:700; letter-spacing:.4px; padding:3px 9px;
+           border-radius:999px; }
+    .tag.pinned { background:rgba(139,123,242,.18); color:#b3a6ff; }
+    .tag.update { background:rgba(91,140,240,.18); color:#8fb2ff; }
+    .tag.event  { background:rgba(215,106,208,.18); color:#f08ddf; }
+    .post .date { font-size:11.5px; font-weight:500; color:#807ea4; margin-left:9px; }
+    .post .title { font-weight:700; font-size:15px; color:#f1effb; margin:9px 0 5px; }
+    .post .body  { font-size:13px; line-height:1.55; color:#a9a7cb; }
+
+    /* Hero card */
+    .hero { position:absolute; right:22px; top:22px; bottom:22px; width:330px; border-radius:16px;
+            overflow:hidden; border:1px solid rgba(255,255,255,.08); background:#11102a; }
+    .hero-bg { position:absolute; top:0; left:0; right:0; bottom:0;
+        background:
+          radial-gradient(120% 70% at 80% -12%, rgba(176,76,176,.42), transparent 54%),
+          radial-gradient(120% 95% at 18% 120%, rgba(60,96,200,.42), transparent 55%),
+          radial-gradient(165% 80% at 50% 150%, rgba(74,150,222,.5), transparent 52%),
+          linear-gradient(180deg,#1a1842,#100e28); }
+    .hero-dots { position:absolute; top:0; left:0; right:0; bottom:0; opacity:.6;
+        background-image:radial-gradient(rgba(212,222,255,.16) 1px, transparent 1.5px); background-size:34px 34px; }
+    .hero-planet { position:absolute; left:50%; bottom:-270px; margin-left:-270px; width:540px; height:540px;
+        border-radius:50%; border-top:1.5px solid rgba(178,226,255,.42);
+        background:radial-gradient(circle at 50% 26%, rgba(124,188,248,.32), rgba(24,42,96,.4) 52%, transparent 70%);
+        box-shadow:inset 0 12px 50px rgba(150,210,255,.32), 0 -2px 46px rgba(120,200,255,.22); }
+    .hero-cap { position:absolute; left:0; right:0; bottom:0; padding:18px 16px 16px;
+        background:linear-gradient(180deg, transparent, rgba(9,8,22,.9) 58%); }
+    .hero-badge { display:inline-block; font-size:10px; font-weight:800; letter-spacing:.6px; color:#fff;
+        background:linear-gradient(135deg,#8b7bf2,#d76ad0); padding:3px 10px; border-radius:999px; margin-bottom:9px; }
+    .hero-title { font-size:15.5px; font-weight:800; color:#f3f1fb; }
+    .hero-sub { font-size:11.5px; font-weight:500; color:#9d9bc6; margin-top:3px; }
+
+    /* Bottom bar */
+    .bottom { position:absolute; left:0; right:0; bottom:0; height:120px; background:#181631;
+              border-top:1px solid rgba(255,255,255,.06); padding:18px 20px; z-index:6; }
+    .pwrap { position:absolute; left:20px; right:230px; top:24px; }
+    .prow { position:relative; height:18px; margin-bottom:10px; }
+    .sdot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:9px; vertical-align:middle;
+            background:#8fb2ff; box-shadow:0 0 8px #8fb2ff; }
+    .stext { font-weight:700; font-size:14px; color:#f1effb; }
+    .itext { font-size:12.5px; color:#8e8cb0; margin-left:9px; }
+    .pct { position:absolute; right:0; top:0; font-size:13px; font-weight:700; color:#8b7bf2; }
+    .ptrack { height:9px; border-radius:999px; background:rgba(255,255,255,.07); overflow:hidden; position:relative; }
+    .pfill { height:100%; width:0%; border-radius:999px; background:linear-gradient(90deg,#8b7bf2,#d76ad0);
+             position:relative; overflow:hidden; }
+    .pshine { position:absolute; top:0; bottom:0; width:40%; animation:xrShimmer 1.6s ease-in-out infinite;
+              background:linear-gradient(90deg, transparent, rgba(255,255,255,.45), transparent); }
+
+    .launch { position:absolute; right:20px; top:32px; height:56px; line-height:56px; padding:0 34px;
+              border-radius:13px; font-weight:800; font-size:17px; letter-spacing:.4px;
+              background:rgba(255,255,255,.06); color:#8a88b0; cursor:default; border:0; }
+    .launch .ico { font-size:14px; margin-right:10px; }
+    .launch.ready { color:#fff; cursor:pointer; background:linear-gradient(135deg,#8b7bf2,#d76ad0);
+                    box-shadow:0 10px 26px -8px rgba(139,123,242,.6); }
+    .launch.ready:hover { box-shadow:0 12px 30px -8px rgba(139,123,242,.8); }
+</style>
 </head>
 <body>
-    <div class="header"><h1>XileRO</h1></div>
-    <div class="content">
-        <div class="status-container">
-            <div class="status-text" id="statusText">Initializing...</div>
-            <div class="progress-bar">
-                <div class="progress-fill" id="progressFill"></div>
-            </div>
+<div class="shell">
+
+    <!-- TITLE BAR -->
+    <div class="titlebar">
+        <div class="tb-left">
+            <div class="logo">X</div>
+            <div class="brand"><b>XILERO</b><span>Launcher</span></div>
+            <div class="ver">{{ config('app.client_version', 'v5.1.0') }}</div>
         </div>
-        <div class="buttons">
-            <button class="btn btn-play" id="btnPlay" disabled onclick="playGame()">Play</button>
-            <button class="btn btn-setup" onclick="openSetup()">Setup</button>
+        <div class="tb-right">
+            <div class="winbtn" title="Settings" onclick="rpc('setup')">&#9881;</div>
+            <div class="winbtn" title="Minimize">&#8212;</div>
+            <div class="winbtn close" title="Exit" onclick="rpc('exit')">&#10005;</div>
         </div>
     </div>
-    <div class="footer">XileRO Patcher</div>
 
-    <script>
-        // Patcher callbacks - called by rpatchur
-        function patchingStatusReady() {
-            document.getElementById('statusText').innerText = 'Ready to play!';
-            document.getElementById('progressFill').style.width = '100%';
-            document.getElementById('btnPlay').disabled = false;
-        }
+    <!-- TOOLBAR -->
+    <div class="toolbar">
+        <div class="nav">
+            <a onclick="openUrl('https://xilero.net/#steps2play')">Register</a>
+            <a onclick="openUrl('https://xilero.net')">Website</a>
+            <a onclick="openUrl('https://discord.gg/xilero')">Discord</a>
+            <a onclick="rpc('setup')">Settings</a>
+        </div>
+        <div class="status-pill">
+            <span class="srv-on"><span class="dot"></span>Server online</span>
+            <span class="sep">&middot;</span>
+            <span class="online" id="playersOnline">&nbsp;</span>
+        </div>
+    </div>
 
-        function patchingStatusError(message) {
-            document.getElementById('statusText').innerText = 'Error: ' + (message || 'Unknown error');
-            document.getElementById('btnPlay').disabled = true;
-        }
+    <!-- STAGE -->
+    <div class="stage">
+        <div class="feed-col">
+            <div>
+                <span class="viewall" onclick="openUrl('https://xilero.net/posts')">View all</span>
+                <div class="feed-head">Latest Updates</div>
+                <div class="feed-sub">News, patches &amp; announcements</div>
+            </div>
+            <div class="xr-feed">
+                @php
+                    $news = $news ?? [
+                        ['tag' => 'pinned', 'label' => 'PINNED', 'date' => 'Always',
+                         'title' => 'Always run your Patcher! ♥',
+                         'body'  => 'Keep the launcher open until patching finishes — it pulls the latest client files so you never fall behind on events.'],
+                        ['tag' => 'update', 'label' => 'UPDATE', 'date' => '4 weeks ago',
+                         'title' => 'New Systems, New Content & Major Changes Ahead',
+                         'body'  => 'We’re testing a few more things and making final adjustments — expect a big content drop for XileRetro very soon.'],
+                        ['tag' => 'event', 'label' => 'EVENT', 'date' => 'April 2026',
+                         'title' => 'Cherry Blossom Bloom',
+                         'body'  => 'Spring has arrived in Rune-Midgard with seasonal quests, blossom drops and limited-time gear.'],
+                    ];
+                @endphp
+                @foreach ($news as $i => $post)
+                    <div class="post {{ $i === 0 ? 'sel' : '' }}" onclick="selectPost(this)">
+                        <span class="tag {{ $post['tag'] }}">{{ $post['label'] }}</span>
+                        <span class="date">{{ $post['date'] }}</span>
+                        <div class="title">{{ $post['title'] }}</div>
+                        <div class="body">{{ $post['body'] }}</div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
 
-        function patchingStatusDownloading(filename, current, total) {
-            var percent = total > 0 ? Math.round((current / total) * 100) : 0;
-            document.getElementById('statusText').innerText = 'Downloading: ' + filename + ' (' + percent + '%)';
-            document.getElementById('progressFill').style.width = percent + '%';
-        }
+        <div class="hero">
+            <div class="hero-bg"></div>
+            <div class="hero-dots"></div>
+            <div class="hero-planet"></div>
+            <div class="hero-cap">
+                <div class="hero-badge">&#9733; FEATURED EVENT</div>
+                <div class="hero-title">Cherry Blossom Bloom</div>
+                <div class="hero-sub">Spring quests &amp; seasonal gear &middot; April 2026</div>
+            </div>
+        </div>
+    </div>
 
-        function patchingStatusInstalling(current, total) {
-            var percent = total > 0 ? Math.round((current / total) * 100) : 0;
-            document.getElementById('statusText').innerText = 'Installing... (' + current + '/' + total + ')';
-            document.getElementById('progressFill').style.width = percent + '%';
-        }
+    <!-- BOTTOM: progress + launch -->
+    <div class="bottom">
+        <div class="pwrap">
+            <div class="prow">
+                <span class="sdot" id="statusDot"></span>
+                <span class="stext" id="statusText">Checking for updates</span>
+                <span class="itext" id="infoText">contacting patch server</span>
+                <span class="pct" id="pct">0%</span>
+            </div>
+            <div class="ptrack"><div class="pfill" id="pfill"><div class="pshine"></div></div></div>
+        </div>
+        <button class="launch" id="launch" onclick="onLaunch()"><span class="ico" id="launchIco">&#8635;</span><span id="launchLabel">Checking…</span></button>
+    </div>
 
-        function patchingStatusPatchApplied(index, total, name) {
-            var percent = total > 0 ? Math.round(((index + 1) / total) * 100) : 0;
-            document.getElementById('statusText').innerText = 'Applied: ' + name;
-            document.getElementById('progressFill').style.width = percent + '%';
-        }
+</div>
 
-        // Actions - call rpatchur functions
-        function playGame() {
-            external.invoke(JSON.stringify({ function: 'play' }));
-        }
+<script>
+    var ready = false;
 
-        function openSetup() {
-            external.invoke(JSON.stringify({ function: 'setup' }));
-        }
+    function el(id) { return document.getElementById(id); }
 
-        // Start patching when page loads
-        window.onload = function() {
-            document.getElementById('statusText').innerText = 'Checking for updates...';
-            setTimeout(function() {
-                external.invoke(JSON.stringify({ function: 'start_update' }));
-            }, 500);
-        };
-    </script>
+    /* Plain-string commands. Only login/open_url use the JSON form in rpatchur. */
+    function rpc(cmd) { external.invoke(cmd); }
+    function openUrl(u) { external.invoke(JSON.stringify({ function: 'open_url', parameters: { url: u } })); }
+
+    function selectPost(node) {
+        var posts = document.getElementsByClassName('post');
+        for (var i = 0; i < posts.length; i++) { posts[i].className = posts[i].className.replace(' sel', ''); }
+        node.className += ' sel';
+    }
+
+    function humanBytes(b) {
+        b = Number(b) || 0;
+        var u = ['B', 'KB', 'MB', 'GB'], i = 0;
+        while (b >= 1024 && i < u.length - 1) { b = b / 1024; i++; }
+        return b.toFixed(1) + ' ' + u[i];
+    }
+
+    function setProgress(pct) {
+        pct = Math.max(0, Math.min(100, Math.round(pct)));
+        el('pfill').style.width = pct + '%';
+        el('pct').innerHTML = pct + '%';
+    }
+    function setDot(color) { el('statusDot').style.background = color; el('statusDot').style.boxShadow = '0 0 8px ' + color; }
+    function setLaunch(label, icon, isReady) {
+        el('launchLabel').innerHTML = label;
+        el('launchIco').innerHTML = icon;
+        el('launch').className = isReady ? 'launch ready' : 'launch';
+        ready = isReady;
+    }
+
+    /* ---- rpatchur -> UI callbacks (signatures match rpatchur's web-view eval calls) ---- */
+    function patchingStatusReady() {
+        el('statusText').innerHTML = 'You’re up to date';
+        el('infoText').innerHTML = 'all files verified';
+        setDot('#46d18a'); setProgress(100);
+        setLaunch('Start Game', '&#9654;', true);
+    }
+    function patchingStatusError(message) {
+        el('statusText').innerHTML = 'Update error';
+        el('infoText').innerHTML = message || 'unknown error';
+        setDot('#e0688a');
+        /* startup_option 3 equivalent: still let the player launch the client */
+        setLaunch('Start Game', '&#9654;', true);
+    }
+    function patchingStatusDownloading(nbDownloaded, nbTotal, bytesPerSec) {
+        el('statusText').innerHTML = 'Downloading updates';
+        el('infoText').innerHTML = nbDownloaded + ' / ' + nbTotal + ' files · ' + humanBytes(bytesPerSec) + '/s';
+        setDot('#8b7bf2');
+        setProgress(nbTotal > 0 ? (nbDownloaded / nbTotal) * 100 : 0);
+        setLaunch('Patching…', '&#8635;', false);
+    }
+    function patchingStatusInstalling(nbInstalled, nbTotal) {
+        el('statusText').innerHTML = 'Installing updates';
+        el('infoText').innerHTML = nbInstalled + ' / ' + nbTotal + ' applied';
+        setDot('#8b7bf2');
+        setProgress(nbTotal > 0 ? (nbInstalled / nbTotal) * 100 : 0);
+        setLaunch('Patching…', '&#8635;', false);
+    }
+    function patchingStatusPatchApplied(fileName) {
+        el('infoText').innerHTML = 'applied ' + fileName;
+    }
+    function notificationInProgress() {
+        el('statusText').innerHTML = 'Patching already in progress…';
+    }
+
+    function onLaunch() { if (ready) { rpc('play'); } }
+
+    window.onload = function () { external.invoke('start_update'); };
+</script>
 </body>
 </html>

--- a/resources/views/rpatchur.blade.php
+++ b/resources/views/rpatchur.blade.php
@@ -167,9 +167,9 @@
             </div>
             <div class="xr-feed">
                 @forelse ($posts as $post)
-                    <div class="post {{ $loop->first ? ‘sel’ : ‘’ }}" onclick="selectPost(this)">
+                    <div class="post {{ $loop->first ? 'sel' : '' }}" onclick="selectPost(this)">
                         <span class="tag update">UPDATE</span>
-                        <span class="date">{{ $post->created_at->format(‘M j, Y’) }}</span>
+                        <span class="date">{{ $post->created_at->format('M j, Y') }}</span>
                         <div class="title">{{ $post->title }}</div>
                         <div class="body">{{ Str::limit($post->patcher_notice ?: strip_tags($post->article_content), 120) }}</div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Auth\DiscordController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\WikiController;
 use App\Models\Patch;
+use App\Models\Post;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -63,16 +64,21 @@ Route::resource('posts', PostController::class)->only(['index', 'show']);
 
 // The rpatchur webview is Internet Explorer (MSHTML) on Windows, which cannot
 // parse Debugbar's injected jQuery/PhpDebugBar scripts (causes IE "Syntax error"
-// / "jQuery is undefined" dialogs). Disable Debugbar for the patcher pages.
-$rpatchur = function () {
+// / "jQuery is undefined" dialogs). Disable Debugbar for the patcher page.
+// XileRetro uses neoncube (legacy patcher) and has no rpatchur route.
+Route::get('xilero/rpatchur', function () {
     if (app()->bound('debugbar')) {
         app('debugbar')->disable();
     }
 
-    return view('rpatchur');
-};
-Route::get('retro/rpatchur', $rpatchur);
-Route::get('xilero/rpatchur', $rpatchur);
+    $posts = Post::query()
+        ->where('client', Post::CLIENT_XILERO)
+        ->latest()
+        ->take(5)
+        ->get();
+
+    return view('rpatchur', compact('posts'));
+});
 
 Route::get('retro/patch/notice', function () {
     $rawPosts = DB::table('posts')

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,8 +61,18 @@ Route::view('/forums', 'forums');
 
 Route::resource('posts', PostController::class)->only(['index', 'show']);
 
-Route::view('retro/rpatchur', 'rpatchur');
-Route::view('xilero/rpatchur', 'rpatchur');
+// The rpatchur webview is Internet Explorer (MSHTML) on Windows, which cannot
+// parse Debugbar's injected jQuery/PhpDebugBar scripts (causes IE "Syntax error"
+// / "jQuery is undefined" dialogs). Disable Debugbar for the patcher pages.
+$rpatchur = function () {
+    if (app()->bound('debugbar')) {
+        app('debugbar')->disable();
+    }
+
+    return view('rpatchur');
+};
+Route::get('retro/rpatchur', $rpatchur);
+Route::get('xilero/rpatchur', $rpatchur);
 
 Route::get('retro/patch/notice', function () {
     $rawPosts = DB::table('posts')
@@ -100,7 +110,7 @@ Route::get('xilero/patch/notice', function () {
 });
 
 Route::get('retro/patch/list', function () {
-    $patches = Patch::where('client', 'retro')->orderBy('number')->get();
+    $patches = Patch::where('client', 'retro')->where('patcher', Patch::PATCHER_LEGACY)->orderBy('number')->get();
 
     $formattedPatches = array_map(function ($patch) {
         $base = sprintf(
@@ -133,7 +143,7 @@ Route::get('retro/patch/list', function () {
 });
 
 Route::get('xilero/patch/list', function () {
-    $patches = Patch::where('client', 'xilero')->orderBy('number')->get();
+    $patches = Patch::where('client', 'xilero')->where('patcher', Patch::PATCHER_LEGACY)->orderBy('number')->get();
 
     $formattedPatches = array_map(function ($patch) {
         $base = sprintf(
@@ -160,6 +170,40 @@ Route::get('xilero/patch/list', function () {
         ->header('Content-Type', 'text/plain; charset=UTF-8')
         ->header('Content-Disposition', 'inline; filename="patchlist.txt"')
         ->header('Content-Length', strlen($content))
+        ->header('Cache-Control', 'no-cache, must-revalidate')
+        ->header('Last-Modified', $lastModified->toRfc7231String())
+        ->header('X-Content-Type-Options', 'nosniff');
+});
+
+// rpatchur patch list (XileRO client). rpatchur parses each line as
+// "<index> <filename>" (it reads words[0]=index, words[1]=file), so we emit
+// exactly that — NO type token — and rely on the .thor file itself to carry the
+// GRF-merge target. Trailing " // comment" is ignored by rpatchur. Only patches
+// flagged patcher='rpatchur' are listed (legacy .gpf entries are excluded).
+Route::get('xilero/rpatchur/list', function () {
+    $patches = Patch::query()
+        ->where('client', Patch::CLIENT_XILERO)
+        ->where('patcher', Patch::PATCHER_RPATCHUR)
+        ->orderBy('number')
+        ->get();
+
+    $lines = $patches->map(function (Patch $patch): string {
+        $line = sprintf('%03d %s', $patch->number, $patch->patch_name);
+
+        if (! empty($patch->comments)) {
+            $line .= ' // '.$patch->comments;
+        }
+
+        return $line;
+    });
+
+    $content = $lines->implode("\r\n");
+    $lastModified = $patches->max('updated_at') ?: now();
+
+    return response($content, 200)
+        ->header('Content-Type', 'text/plain; charset=UTF-8')
+        ->header('Content-Disposition', 'inline; filename="plist.txt"')
+        ->header('Content-Length', (string) strlen($content))
         ->header('Cache-Control', 'no-cache, must-revalidate')
         ->header('Last-Modified', $lastModified->toRfc7231String())
         ->header('X-Content-Type-Options', 'nosniff');

--- a/tests/Feature/Filament/PatchResourceTest.php
+++ b/tests/Feature/Filament/PatchResourceTest.php
@@ -10,6 +10,7 @@ use App\Models\Patch;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
@@ -26,6 +27,7 @@ class PatchResourceTest extends TestCase
 
         Storage::fake('xilero_patch');
         Storage::fake('retro_patch');
+        Storage::fake('xilero_rpatchur');
     }
 
     #[Test]
@@ -85,11 +87,58 @@ class PatchResourceTest extends TestCase
         Livewire::actingAs($admin)
             ->test(CreatePatch::class)
             ->fillForm([
+                'patcher' => Patch::PATCHER_LEGACY,
                 'type' => '',
                 'client' => '',
             ])
             ->call('create')
             ->assertHasFormErrors(['type', 'client']);
+    }
+
+    #[Test]
+    public function rpatchur_patch_rejects_a_legacy_gpf_upload(): void
+    {
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        $admin = User::factory()->admin()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CreatePatch::class)
+            ->fillForm([
+                'patcher' => Patch::PATCHER_RPATCHUR,
+                'client' => Patch::CLIENT_XILERO,
+                'patch_name' => 'wrong-format',
+                'file' => UploadedFile::fake()->create('patch.gpf', 100),
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['file']);
+    }
+
+    #[Test]
+    public function rpatchur_patch_accepts_a_thor_upload_without_a_type(): void
+    {
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        Queue::fake();
+
+        $admin = User::factory()->admin()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CreatePatch::class)
+            ->fillForm([
+                'patcher' => Patch::PATCHER_RPATCHUR,
+                'client' => Patch::CLIENT_XILERO,
+                'patch_name' => 'first.thor',
+                'file' => UploadedFile::fake()->create('first.thor', 100),
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas(Patch::class, [
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'patch_name' => 'first.thor',
+            'type' => 'FLD',
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/Filament/PatchResourceTest.php
+++ b/tests/Feature/Filament/PatchResourceTest.php
@@ -142,8 +142,10 @@ class PatchResourceTest extends TestCase
     }
 
     #[Test]
-    public function retro_client_rejects_the_rpatchur_patcher(): void
+    public function retro_client_derives_the_legacy_patcher(): void
     {
+        Queue::fake();
+
         Filament::setCurrentPanel(Filament::getPanel('admin'));
 
         $admin = User::factory()->admin()->create();
@@ -152,12 +154,18 @@ class PatchResourceTest extends TestCase
             ->test(CreatePatch::class)
             ->fillForm([
                 'client' => Patch::CLIENT_RETRO,
-                'patcher' => Patch::PATCHER_RPATCHUR,
                 'type' => 'FLD',
                 'patch_name' => 'retro.gpf',
+                'file' => UploadedFile::fake()->create('retro.gpf', 100),
             ])
             ->call('create')
-            ->assertHasFormErrors(['patcher']);
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas(Patch::class, [
+            'client' => Patch::CLIENT_RETRO,
+            'patcher' => Patch::PATCHER_LEGACY,
+            'patch_name' => 'retro.gpf',
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/Filament/PatchResourceTest.php
+++ b/tests/Feature/Filament/PatchResourceTest.php
@@ -142,6 +142,25 @@ class PatchResourceTest extends TestCase
     }
 
     #[Test]
+    public function retro_client_rejects_the_rpatchur_patcher(): void
+    {
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        $admin = User::factory()->admin()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CreatePatch::class)
+            ->fillForm([
+                'client' => Patch::CLIENT_RETRO,
+                'patcher' => Patch::PATCHER_RPATCHUR,
+                'type' => 'FLD',
+                'patch_name' => 'retro.gpf',
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['patcher']);
+    }
+
+    #[Test]
     public function admin_can_filter_patches_by_type(): void
     {
         Filament::setCurrentPanel(Filament::getPanel('admin'));

--- a/tests/Feature/RpatchurPatchListTest.php
+++ b/tests/Feature/RpatchurPatchListTest.php
@@ -26,6 +26,21 @@ class RpatchurPatchListTest extends TestCase
     }
 
     #[Test]
+    public function the_hero_shows_the_latest_post_image(): void
+    {
+        Post::factory()->create([
+            'client' => Post::CLIENT_XILERO,
+            'title' => 'June Update',
+            'image' => 'post-images/june.jpg',
+        ]);
+
+        $this->get('/xilero/rpatchur')
+            ->assertOk()
+            ->assertSee('hero-img')
+            ->assertSee('post-images/june.jpg');
+    }
+
+    #[Test]
     public function it_lists_only_xilero_rpatchur_patches_in_rpatchur_format(): void
     {
         Patch::factory()->create([

--- a/tests/Feature/RpatchurPatchListTest.php
+++ b/tests/Feature/RpatchurPatchListTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Patch;
+use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -10,6 +11,19 @@ use Tests\TestCase;
 class RpatchurPatchListTest extends TestCase
 {
     use RefreshDatabase;
+
+    #[Test]
+    public function the_rpatchur_launcher_page_renders(): void
+    {
+        $post = Post::factory()->create([
+            'client' => Post::CLIENT_XILERO,
+            'title' => 'June Update',
+        ]);
+
+        $this->get('/xilero/rpatchur')
+            ->assertOk()
+            ->assertSee($post->title);
+    }
 
     #[Test]
     public function it_lists_only_xilero_rpatchur_patches_in_rpatchur_format(): void

--- a/tests/Feature/RpatchurPatchListTest.php
+++ b/tests/Feature/RpatchurPatchListTest.php
@@ -78,4 +78,28 @@ class RpatchurPatchListTest extends TestCase
         $response->assertSee('old.gpf');
         $response->assertDontSee('new.thor');
     }
+
+    #[Test]
+    public function the_retro_legacy_list_excludes_rpatchur_patches(): void
+    {
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_RETRO,
+            'patcher' => Patch::PATCHER_LEGACY,
+            'number' => 1,
+            'type' => 'FLD',
+            'patch_name' => 'retro.gpf',
+        ]);
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_RETRO,
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'number' => 2,
+            'patch_name' => 'never.thor',
+        ]);
+
+        $response = $this->get('/retro/patch/list');
+
+        $response->assertOk();
+        $response->assertSee('retro.gpf');
+        $response->assertDontSee('never.thor');
+    }
 }

--- a/tests/Feature/RpatchurPatchListTest.php
+++ b/tests/Feature/RpatchurPatchListTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Patch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RpatchurPatchListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_lists_only_xilero_rpatchur_patches_in_rpatchur_format(): void
+    {
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_XILERO,
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'number' => 2,
+            'type' => 'FLD',
+            'patch_name' => 'second.thor',
+            'comments' => 'second patch',
+        ]);
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_XILERO,
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'number' => 1,
+            'type' => 'GRF',
+            'patch_name' => 'first.thor',
+            'comments' => null,
+        ]);
+
+        // Must be excluded: legacy xilero patch and an rpatchur patch for another client.
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_XILERO,
+            'patcher' => Patch::PATCHER_LEGACY,
+            'number' => 3,
+            'patch_name' => 'legacy.gpf',
+        ]);
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_RETRO,
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'number' => 4,
+            'patch_name' => 'retro.thor',
+        ]);
+
+        $response = $this->get('/xilero/rpatchur/list');
+
+        $response->assertOk();
+        // rpatchur format: "<zero-padded index> <filename>" ordered by number,
+        // no type token, optional " // comment". Legacy/retro excluded.
+        $response->assertSee("001 first.thor\r\n002 second.thor // second patch", false);
+        $response->assertDontSee('legacy.gpf');
+        $response->assertDontSee('retro.thor');
+    }
+
+    #[Test]
+    public function the_legacy_list_excludes_rpatchur_patches(): void
+    {
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_XILERO,
+            'patcher' => Patch::PATCHER_LEGACY,
+            'number' => 10,
+            'type' => 'GRF',
+            'patch_name' => 'old.gpf',
+        ]);
+        Patch::factory()->create([
+            'client' => Patch::CLIENT_XILERO,
+            'patcher' => Patch::PATCHER_RPATCHUR,
+            'number' => 11,
+            'patch_name' => 'new.thor',
+        ]);
+
+        $response = $this->get('/xilero/patch/list');
+
+        $response->assertOk();
+        $response->assertSee('old.gpf');
+        $response->assertDontSee('new.thor');
+    }
+}


### PR DESCRIPTION
Serves THOR/GRF patches to the modern **rpatchur** launcher for the XileRO client, kept separate from the legacy `.gpf` Thor patcher.

## What's included
- **`patcher` discriminator** (`legacy` | `rpatchur`) on `patches` + new `xilero_rpatchur` storage disk, so the legacy and new systems never mix.
- **New plist endpoint** `GET /xilero/rpatchur/list` emitting rpatchur's `<index> <filename>` format (no `type` token — the `.thor` carries the GRF-merge target internally). Legacy `/xilero/patch/list` and `/retro/patch/list` now exclude rpatchur patches.
- **PatchResource admin**: the patcher is derived from the client (XileRO => rpatchur, XileRetro => legacy) rather than chosen separately, so the form is just Client + Patch Type. rpatchur uploads route to the new disk; uploads are extension-validated per patcher (`.gpf` for legacy, `.thor`/`.grf` for rpatchur). Download action + `CompilePatch` resolve the disk via `Patch::diskName()`.
- **`rpatchur.blade.php`**: rebuilt as the IE11/MSHTML-safe launcher UI (rpatchur's webview is Internet Explorer) wired to rpatchur's real JS API — correct `patchingStatus*` signatures and plain-string `play`/`setup`/`start_update`. Renders real XileRO `Post` records. Debugbar + Boost browser-logger injection disabled on the patcher routes (their modern JS throws IE11 script errors).
- XileRetro stays on the legacy neoncube patcher — no retro rpatchur route or disk.

## Review follow-ups
All findings from the review pass are resolved: removed dead `getDiskForClient()`, added the explicit `xilero/rpatchur` symlink, defaulted `PatchFactory` patcher, scoped the "Recent Patches" list by patcher + client, and added per-patcher upload restrictions plus the conditional `type` field.

## Tested
- `tests/Feature/RpatchurPatchListTest.php` — plist format + legacy/rpatchur separation, incl. `retro/patch/list` exclusion.
- `tests/Feature/Filament/PatchResourceTest.php` — per-patcher upload validation and patcher-derived-from-client behaviour.
- Full suite green under Laravel Sail: 962 passed, 1 skipped, 1 risky, 0 failed.
- End-to-end: `rpatchur.exe` fetched the plist, downloaded `.thor` patches, merged one into `data.grf` and extracted the other to `System\`.

## Not included (deliberately)
- Recompiled `public/` assets — out of scope for this PR.
- Patch authoring uses a local `mkpatch` wrapper (`make-patch.ps1` in the client repo); server-side `.thor` generation can come later.

> Local Laravel Sail dev setup (`docker-compose.yml` + MariaDB init script) is now present via a `master` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

